### PR TITLE
Fix audio exceptions on Linux

### DIFF
--- a/lib/terminal_game_engine/sound.rb
+++ b/lib/terminal_game_engine/sound.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'shellwords'
 
 module TerminalGameEngine
   class Sound
@@ -7,7 +8,7 @@ module TerminalGameEngine
       when /darwin/
         stdin, stdout, stderr, wait_thr = Open3.popen3('afplay', path)
       when /linux/
-        stdin, stdout, stderr, wait_thr = Open3.popen3('command -v mplayer >/dev/null 2>&1 && mplayer -msglevel all=-1 -nolirc', path)
+        stdin, stdout, stderr, wait_thr = Open3.popen3("command -v mplayer >/dev/null 2>&1 && mplayer -msglevel all=-1 -nolirc #{path.shellescape}")
       end
 
       Thread.new do

--- a/lib/terminal_game_engine/sound.rb
+++ b/lib/terminal_game_engine/sound.rb
@@ -15,6 +15,7 @@ module TerminalGameEngine
         while line = stderr.readline
           logger.error line.chomp
         end
+      rescue EOFError
       end
     end
   end


### PR DESCRIPTION
## Fix Linux audio command

`Open3.popen3` requires the command in one of [a few forms](https://docs.ruby-lang.org/en/2.0.0/Process.html#method-c-spawn):

- Arguments of: command + arguments
- An array of: command + arguments
- A string of command + arguments

Previously, with multiple arguments, it was using the first form, and so trying to run an executable that has the name `command -v mplayer >/dev/null 2>&1 && mplayer -msglevel all=-1 -nolirc`, which obviously doesn't exist (and providing one command-line argument, being the audio file `path`).

Hence this error prevented startup of Snek:

```
➜ (cd ../snek && bundle _1.17.3_ exec ./bin/snek)
bundler: failed to load command: ./bin/snek (./bin/snek)
Errno::ENOENT: No such file or directory - command -v mplayer >/dev/null 2>&1 && mplayer -msglevel all=-1 -nolirc
  /home/brendan/.rbenv/versions/2.7.2/lib/ruby/2.7.0/open3.rb:213:in `spawn'
  /home/brendan/.rbenv/versions/2.7.2/lib/ruby/2.7.0/open3.rb:213:in `popen_run'
  /home/brendan/.rbenv/versions/2.7.2/lib/ruby/2.7.0/open3.rb:101:in `popen3'
  /home/brendan/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/terminal_game_engine-0.1.2/lib/terminal_game_engine/sound.rb:10:in `play'
  /home/brendan/Projects/snek/lib/game.rb:278:in `play_sound'
  /home/brendan/Projects/snek/lib/game.rb:21:in `start'
  /home/brendan/Projects/snek/bin/snek:19:in `<top (required)>'
```

Converting the command into one of the first two forms doesn't work, as the `command` command is actually a shell built-in command (so not available outside of a shell) and only the third form uses a shell to evaluate the given command. Thus, we need to use shellwords to safely escape the path.

---

## Prevent EOFError from mplayer on Linux

Now that Snek starts up, it was showing this below the the game screen:

```
1: from /home/brendan/Projects/terminal_game_engine/lib/terminal_game_engine/sound.rb:15:in `block in play'
/home/brendan/Projects/terminal_game_engine/lib/terminal_game_engine/sound.rb:15:in `readline': end of file reached (EOFError)
```