### PR TITLE
Fix NoMethodError for $stdin.raw!

### DIFF
--- a/lib/terminal_game_engine/frame.rb
+++ b/lib/terminal_game_engine/frame.rb
@@ -1,3 +1,5 @@
+require 'io/console'
+
 module TerminalGameEngine
   class Frame
     attr_reader :rows


### PR DESCRIPTION
By requiring 'io/console'

Resolves https://github.com/twe4ked/terminal_game_engine/issues/3.

```
Traceback (most recent call last):
	2: from examples/counter.rb:3:in `<main>'
	1: from /home/brendan/Projects/terminal_game_engine/lib/terminal_game_engine.rb:5:in `run'
/home/brendan/Projects/terminal_game_engine/lib/terminal_game_engine/frame.rb:71:in `setup': undefined method `raw!' for #<IO:<STDIN>> (NoMethodError)
```

Turns out [the docs for `IO.raw!`](https://ruby-doc.org/stdlib-2.4.0/libdoc/io/console/rdoc/IO.html#method-i-raw-21) say:

> You must require 'io/console' to use this method.